### PR TITLE
fixed next Link error issue on the latest devices slug page

### DIFF
--- a/app/(client)/latestdevices/[page]/page.jsx
+++ b/app/(client)/latestdevices/[page]/page.jsx
@@ -3,6 +3,7 @@ import React from "react";
 import AdBanner from "@/app/components/AdBanner";
 import { fetchedLatestDevices } from "@/lib/fetchedDevices";
 import Head from "next/head";
+import Link from "next/link";
 
 export const dynamic = "force-dynamic";
 const baseURL = process.env.NEXT_PUBLIC_BASE_URL;


### PR DESCRIPTION
fixed next Link error issue on the latest devices slug page. This was affecting the live website and causing it to break when you try to load all the latest devices page